### PR TITLE
Add platform to Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.4'
 
 target 'Health' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks


### PR DESCRIPTION
Silences the below warning:

```
[!] Automatically assigning platform `iOS` with version `11.4` on target `Health` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.

```