### PR TITLE
Fixed background color for surveys, updated minimum ios

### DIFF
--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -721,6 +721,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)/**";
 				INFOPLIST_FILE = Health/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -750,6 +751,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)/**";
 				INFOPLIST_FILE = Health/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Health/SurveyViewController.swift
+++ b/Health/SurveyViewController.swift
@@ -132,7 +132,7 @@ class SurveyViewController: UIViewController {
         manager.add(schedule)
         
         let esmViewController = ESMScrollViewController.init()
-        esmViewController.view.backgroundColor = .white
+        esmViewController.view.backgroundColor = .systemBackground
         let naviController = UINavigationController.init(rootViewController: esmViewController)
         
         if allowClose {


### PR DESCRIPTION
Fixes #20 . 

Previously the background in the ESM was set to white while text was automatic, which didn't work for dark mode. This makes the background color automatic as well. However, automatic background color (without wrapping in a #if) required updating the project's target iOS version to 13.0.

![image](https://user-images.githubusercontent.com/16804460/81094945-22abcd80-8eb9-11ea-9112-0ee1ecb62edf.png)
